### PR TITLE
feat: Display MapComponent and add placeholder

### DIFF
--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -1,3 +1,24 @@
 p {
   font-family: Lato;
 }
+
+/* Ensure the root Angular component and HTML/body take full height */
+:host {
+  display: block;
+  height: 100vh;
+  width: 100vw;
+  overflow: hidden; /* Prevent scrollbars on the body */
+}
+
+/* Make app-gmap and app-map stack vertically, each taking 50% of the host's height */
+app-gmap, app-map {
+  display: block; /* Or flex, grid item depending on desired layout */
+  width: 100%;
+  height: 50vh; /* 50% of the viewport height */
+  box-sizing: border-box; /* Include padding and border in the element's total width and height */
+}
+
+/* Optional: Add a border to easily distinguish them */
+app-gmap {
+  border-bottom: 1px solid #ccc;
+}

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,1 +1,2 @@
 <app-gmap></app-gmap>
+<app-map></app-map>

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -58,6 +58,13 @@ export class MapComponent implements OnInit, AfterViewInit, OnDestroy {
     this.renderer.setSize(width, height);
     container.appendChild(this.renderer.domElement);
 
+    // Add an initial placeholder cube
+    const placeholderGeometry = new THREE.BoxGeometry(0.8, 0.8, 0.8); // Slightly smaller
+    const placeholderMaterial = new THREE.MeshBasicMaterial({ color: 0x0000ff }); // Blue
+    const placeholderCube = new THREE.Mesh(placeholderGeometry, placeholderMaterial);
+    placeholderCube.position.set(-1.5, 0, 0); // Position it to the side
+    this.scene.add(placeholderCube);
+
     this.animate();
   }
 


### PR DESCRIPTION
Integrates the MapComponent (Three.js scene) into the main application view, allowing it to be displayed alongside the GMapComponent (Google Maps).

Key changes:
- Modified `app.component.html` to include `<app-map>`.
- Added CSS to `app.component.css` to stack `app-gmap` and `app-map` vertically, each taking 50% of the viewport height.
- Verified that `MapComponent`'s existing API call to `/api/maps` and its error handling (displaying a red cube) function as intended (the API call is expected to fail).
- Added an initial blue placeholder cube to `MapComponent` that is visible on load, providing immediate feedback in the 3D scene.

This makes the 3D rendering capabilities of the application visible as per your project's goals.